### PR TITLE
Add issue template for tracking websites to load

### DIFF
--- a/.github/ISSUE_TEMPLATE/websites_to_load.yaml
+++ b/.github/ISSUE_TEMPLATE/websites_to_load.yaml
@@ -29,14 +29,15 @@ body:
       options: 
         - Need help with entity identifier
         - Waiting for the provider to make changes to their data
+        - Not sure
   - type: checkboxes
     id: autominting
     attributes:
-      label: Autominting
+      label: ### Autominting
       description: "Check this box if the source should be autominted."
       options: Ready for autominting
   - type: textarea
     id: Notes
     attributes:
-      label: Notes
+      label: ### Notes
       description: "Provide any other relevant information. For example, if this website is meant to replace an older source, provide the name of the graph that should be deleted."

--- a/.github/ISSUE_TEMPLATE/websites_to_load.yaml
+++ b/.github/ISSUE_TEMPLATE/websites_to_load.yaml
@@ -7,25 +7,25 @@ body:
   - type: input
     id: event-webpage
     attributes:
-      label: ### Event webpage URL
+      label: Event webpage URL
       description: "Enter the URL of the webpage where events are listed"
       placeholder: "https://example.com/whats-on/"
   - type: input
     id: structured-data-score
     attributes:
-      label: ### Structured data score
+      label: Structured data score
       description: "Enter the structured data score as a percentage value."
       placeholder: "72"
   - type: input
     id: entity-identifier
     attributes:
-      label: ### Entity identifier
+      label: Entity identifier
       description: "Enter the CSS selector. Leave this field empty if you are unable to figure out the selector."
       placeholder: "div.tribe-events-pro-photo__event-featured-image-wrapper"
   - type: dropdown
     id: status
     attributes:
-      label: ### Status
+      label: Status
       options: 
         - Need help with entity identifier
         - Waiting for the provider to make changes to their data
@@ -33,11 +33,11 @@ body:
   - type: checkboxes
     id: autominting
     attributes:
-      label: ### Autominting
+      label: Autominting
       description: "Check this box if the source should be autominted."
       options: Ready for autominting
   - type: textarea
     id: Notes
     attributes:
-      label: ### Notes
+      label: Notes
       description: "Provide any other relevant information. For example, if this website is meant to replace an older source, provide the name of the graph that should be deleted."

--- a/.github/ISSUE_TEMPLATE/websites_to_load.yaml
+++ b/.github/ISSUE_TEMPLATE/websites_to_load.yaml
@@ -1,0 +1,42 @@
+name: Websites to load
+description: Use to track event sources that should be loaded to Artsdata now or at some point in the near future.
+title: "[Website to load]: "
+labels: ["Websites to load"]
+
+body:
+  - type: input
+    id: event-webpage
+    attributes:
+      label: ### Event webpage URL
+      description: "Enter the URL of the webpage where events are listed"
+      placeholder: "https://example.com/whats-on/"
+  - type: input
+    id: structured-data-score
+    attributes:
+      label: ### Structured data score
+      description: "Enter the structured data score as a percentage value."
+      placeholder: "72"
+  - type: input
+    id: entity-identifier
+    attributes:
+      label: ### Entity identifier
+      description: "Enter the CSS selector. Leave this field empty if you are unable to figure out the selector."
+      placeholder: "div.tribe-events-pro-photo__event-featured-image-wrapper"
+  - type: dropdown
+    id: status
+    attributes:
+      label: ### Status
+      options: 
+        - Need help with entity identifier
+        - Waiting for the provider to make changes to their data
+  - type: checkboxes
+    id: autominting
+    attributes:
+      label: Autominting
+      description: "Check this box if the source should be autominted."
+      options: Ready for autominting
+  - type: textarea
+    id: Notes
+    attributes:
+      label: Notes
+      description: "Provide any other relevant information. For example, if this website is meant to replace an older source, provide the name of the graph that should be deleted."


### PR DESCRIPTION
@saumier I designed this issues template to track event sources that should be loaded to Artsdata in the near future. 

Note: This issue template really belongs in the Orion repo. However, CAPACOA staff members may expect to find it in the support repo. Once you've reviewed the template, please make a copy of it in Orion repo.